### PR TITLE
fix: as.list returns a `list` instead of a `SimpleList`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CompoundDb
 Type: Package
 Title: Creating and using (Chemical) Compound Annotation Databases
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(person(given = "Jan", family = "Stanstrup",
                     email = "stanstrup@gmail.com",
 		    role = c("aut"),

--- a/R/MsBackendCompDb.R
+++ b/R/MsBackendCompDb.R
@@ -39,7 +39,7 @@
 #' methods are inherited directly from the parent [MsBackendDataFrame()] class.
 #' See that help page for a complete listing of methods.
 #'
-#' - `as.list`: gets the full list of peak matrices. Returns a [SimpleList()],
+#' - `as.list`: gets the full list of peak matrices. Returns a [list()],
 #'   length equal to the number of spectra and each element being a `matrix`
 #'   with columns `"mz"` and `"intensity"` with the spectra's m/z and intensity
 #'   values.
@@ -137,8 +137,8 @@ setMethod("show", "MsBackendCompDb", function(object) {
 #' @export
 setMethod("as.list", "MsBackendCompDb", function(x) {
     if (!length(x))
-        return(SimpleList())
-    SimpleList(.peaks(x))
+        return(list())
+    .peaks(x)
 })
 
 #' @importFrom IRanges NumericList

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+Changes in version 0.4.2
+
+- Fix bug in `as.list,MsBackendCompDb` which returned a `SimpleList` instead of
+  a `list`.
+
+
 Changes in version 0.4.0
 
 - Rename method `spectraData` for `MsBackendCompDb` into `asDataFrame`

--- a/man/MsBackendCompDb.Rd
+++ b/man/MsBackendCompDb.Rd
@@ -78,7 +78,7 @@ The methods listed here are implemented for the \code{MsBackendCompDb}. All othe
 methods are inherited directly from the parent \code{\link[=MsBackendDataFrame]{MsBackendDataFrame()}} class.
 See that help page for a complete listing of methods.
 \itemize{
-\item \code{as.list}: gets the full list of peak matrices. Returns a \code{\link[=SimpleList]{SimpleList()}},
+\item \code{as.list}: gets the full list of peak matrices. Returns a \code{\link[=list]{list()}},
 length equal to the number of spectra and each element being a \code{matrix}
 with columns \code{"mz"} and \code{"intensity"} with the spectra's m/z and intensity
 values.

--- a/tests/testthat/test_MsBackendCompDb.R
+++ b/tests/testthat/test_MsBackendCompDb.R
@@ -25,11 +25,11 @@ test_that("as.list,MsBackendCompDb works", {
     be <- MsBackendCompDb()
     res <- as.list(be)
     expect_true(length(res) == 0)
-    expect_true(is(res, "SimpleList"))
+    expect_true(is(res, "list"))
 
     be <- Spectra(cmp_spctra_db)@backend
     res <- as.list(be)
-    expect_true(is(res, "SimpleList"))
+    expect_true(is(res, "list"))
     expect_true(length(res) == length(be))
     expect_true(is.matrix(res[[1]]))
     expect_true(all(colnames(res[[2]]) %in% c("mz", "intensity")))


### PR DESCRIPTION
- Change `as.list` to return a `list` instead of a `SimpleList`.