### PR TITLE
feat: Add spectra_type/ms_level and precursor_type parse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,11 @@ Authors@R: c(person(given = "Jan", family = "Stanstrup",
              person(given = "Johannes", family = "Rainer",
 	            email = "johannes.rainer@eurac.edu",
 		    role = c("aut", "cre"),
-		    comment = c(ORCID = "0000-0002-6977-7147"))
+		    comment = c(ORCID = "0000-0002-6977-7147")),
+		     person(given = "Josep M.", family = "Badia",
+		        email = "josepmaria.badia@urv.cat",
+		    role = c("ctb"),
+		    comment = c(ORCID = "0000-0002-5704-1124"))
 		    )
 Author: Johannes Rainer and Jan Stanstrup
 Maintainer: Johannes Rainer <johannes.rainer@eurac.edu>

--- a/R/spectrum-import-functions.R
+++ b/R/spectrum-import-functions.R
@@ -290,11 +290,11 @@ msms_spectra_mona <- function(x, collapsed = TRUE) {
     message("OK")
     colnames(spctra)[colnames(spctra) == "precursor_type"] <- "adduct"
     spec_trim <- gsub(" ", "", spctra$spectrum_type, fixed = TRUE)
-    is_mslevel <- grepl("^ms\\d+$", spec_trim, ignore.case = T)
+    is_mslevel <- grepl("^ms\\d+$", spec_trim, ignore.case = TRUE)
     if(any(is_mslevel)){
         spctra$ms_level <- rep(NA_integer_, length(spec_trim))
         spctra$ms_level[is_mslevel] <- as.integer(
-            sub("ms", "", spec_trim[is_mslevel], ignore.case = T))
+            sub("ms", "", spec_trim[is_mslevel], ignore.case = TRUE))
     }
     if (collapsed) spctra
     else .expand_spectrum_df(spctra)

--- a/man/msms_spectra_mona.Rd
+++ b/man/msms_spectra_mona.Rd
@@ -30,6 +30,8 @@ provided.
 spectrum was measured.
 \item instrument (\code{character}): the MS instrument.
 \item precursor_mz (\code{numeric}): precursor m/z.
+\item adduct (\code{character}): ion formed from the precursor ion.
+\item ms_level (\code{integer}): stage of the sequential mass spectrometry (MSn).
 \item mz (\code{numeric} or \code{list} of \code{numeric}): m/z values of the spectrum.
 \item intensity (\code{numeric} or \code{list} of \code{numeric}): intensity of the spectrum.
 }


### PR DESCRIPTION
Added `spectra_type` and `precursor_type` parse to the generic `.extract_spectra_mona_sdf()` function. 
Also, when this function is called from `msms_spectra_mona()` function, `spectra_type` is duplicated to `ms_level` (as integer) and `precursor_type` is renamed to `adduct`.
It is not exactly what we talked about. Please check. @jorainer 